### PR TITLE
Add support for chains and make it easier to override behaviour.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/vendor
 composer.lock
 /.idea
+.phpunit.result.cache
+/vendor

--- a/README.md
+++ b/README.md
@@ -1,33 +1,38 @@
 # Laravel Queue Debouncer
+
 ### Easy queue job debouncing
 
 ## Requirements
-* Laravel >= 6.0
-* An async queue driver
+
+- Laravel >= 6.0
+- An async queue driver
 
 **Note:** v2.0 requires at least Laravel 6. For Laravel 5.5 ..< 6.0 support, check out [v1.0.2](https://github.com/mpbarlow/laravel-queue-debouncer/tree/1.0.2)
 
 ## Installation
+
 `composer require mpbarlow/laravel-queue-debouncer`
 
 ## Background
-This package allows any queue job in your Laravel application to be debounced, meaning that no matter how many times it’s dispatched within the specified timeout window, it will only actually be ran once.
 
-For example, imagine you want to send an email each time a user changes their contact details, but you don’t want to spam them if they make several changes in a short space of time. Debouncing the job with a five minute wait would ensure they only receive a single email, no matter how many changes they make within that five minutes.
+This package allows any queue job or chain in your Laravel application to be debounced, meaning that no matter how many times it’s dispatched within the specified timeout window, it will only run once.
 
-Version 2.0 is a complete rewrite and brings numerous improvements to the capabilities and ergonomics of the package, as well as thorough test coverage.
+For example, imagine you dispatch a job to rebuild a cache every time a record is updated, but the job is resource intensive. Debouncing the job with a five minute wait would ensure that the cache is only rebuilt once, five minutes after you finish making changes.
 
 ## Usage
-Debounced jobs can largely be treated like any other dispatched job. The debouncer takes two arguments, the actual `$job` you want to run, and the `$wait` period. 
 
-As with a regular dispatch, `$job` can be either a class implementing `Illuminate\Foundation\Bus\Dispatchable` or a closure. `$wait` accepts any argument that the `delay` method on a dispatch accepts (i.e. a `DateTimeInterface` or a number of seconds). 
+Debounced jobs can largely be treated like any other dispatched job. The debouncer takes two arguments, the actual `$job` you want to run, and the `$wait` period.
+
+As with a regular dispatch, `$job` can be either a class implementing `Illuminate\Foundation\Bus\Dispatchable`, a chain, or a closure. `$wait` accepts any argument that the `delay` method on a dispatch accepts (i.e. a `DateTimeInterface` or a number of seconds).
 
 The debouncer returns an instance of `Illuminate\Foundation\Bus\PendingDispatch`, meaning the debouncing process itself may be assigned to a different queue or otherwise manipulated.
 
 ### Calling the debouncer
-There are several ways to initiate debouncing of a job:
+
+There are several ways to use the debouncer:
 
 #### Dependency Injection
+
 ```php
 use App\Jobs\MyJob;
 use Mpbarlow\LaravelQueueDebouncer\Debouncer;
@@ -45,6 +50,7 @@ class MyController
 ```
 
 #### Facade
+
 ```php
 use App\Jobs\MyJob;
 use Mpbarlow\LaravelQueueDebouncer\Facade\Debouncer;
@@ -53,15 +59,14 @@ Debouncer::debounce(new MyJob, 30);
 ```
 
 #### Helper function
+
 ```php
 use App\Jobs\MyJob;
 
 debounce(new MyJob(), 30);
 ```
 
-Of course, you may substitute the job class for a closure.
-
-When monitoring the queue, you will see an entry for the package’s internal dispatcher each time the debounced job is queued, but the job itself will only run once, when the final wait time has expired. 
+When monitoring the queue, you will see an entry for the package’s internal dispatcher each time the debounced job is queued, but the job itself will only run once, when the final wait time has expired.
 
 For example, assuming the following code was ran at exactly 9am:
 
@@ -102,7 +107,8 @@ Hello!
 ```
 
 ## Customising Behaviour
-This package provides a few knobs and dials to customise things to your needs. To override the default behaviour, you should publish the config file:
+
+This package provides a few hooks to customise things to your needs. To override the default behaviour, you should publish the config file:
 
 ```
 php artisan vendor:publish --provider="Mpbarlow\LaravelQueueDebouncer\ServiceProvider"
@@ -111,25 +117,54 @@ php artisan vendor:publish --provider="Mpbarlow\LaravelQueueDebouncer\ServicePro
 This will copy `queue_debouncer.php` to your config directory.
 
 ### Cache key provider
-To support multiple jobs being debounced, the package generates a unique key in the cache for each job type. This key is used as a lookup when the wait for a given dispatch expires, to determine whether the job should be ran or not.
 
-The default implementation works as follows:
-* For class-based jobs, use the fully-qualified class name
-* For closure-based jobs, compute the SHA1 hash of a reflected representation of the closure
-* Prepend the `cache_prefix` value from the config, separated by a colon (‘:’)
+To identify the job being debounced, the package generates a unique key in the cache for each job type.
 
-If the default behaviour works for you, but you’d like to use a different cache prefix, you may simply override that value.
+Two cache key providers are included:
 
-Alternatively, you can provide your own class to produce a key for a given job. This is useful in cases where you have jobs that are implemented as different classes but should be considered the same job for the purposes of debouncing.
+- `Mpbarlow\LaravelQueueDebouncer\Support\CacheKeyProvider` (default): uses the config's `cache_prefix` value with either: the fully-qualified class name for class-based jobs; or a SHA1 hash of the closure for closure jobs.
+- `Mpbarlow\LaravelQueueDebouncer\Support\SerializingCacheKeyProvider`: uses the config's `cache_prefix` value with a SHA1 hash of the serialized job. If you want to debounce jobs based on factors beyond their class name (for example, some internal state), this is the provider to use. This is also required if you need to debounce chains, as the default provider will debounce _all_ chains dispatched by your application as if they are the same job, regardless of what jobs are contained within.
 
-Your provider class must implement `Mpbarlow\LaravelQueueDebouncer\Contracts\CacheKeyProvider`. Please note that your class is responsible for fetching and prepending the cache prefix should you still desire this behaviour—it will not be added automatically.
+Alternatively, you can provide your own class or closure to cover any other behaviour you might need:
 
-**Note:** Because of the limited ways we have to produce a value representation of a closure, only the _exact same closure_ will produce the same cache key. So, while closures originating from the same line in the same file will produce the same key on subsequent requests, two closures with the same content dispatched from different places will not.
+If you provide a class, it should implement `Mpbarlow\LaravelQueueDebouncer\Contracts\CacheKeyProvider`. Please note that your class is responsible for fetching and prepending the cache prefix should you still desire this behaviour.
+
+Class-based providers may be globally registered as the default provider by changing the `cache_key_provider` value in the config. Alternatively, you may "hot-swap" the provider using the `usingUniqueIdentifierProvider` method:
+
+```php
+$debouncer
+    ->usingCacheKeyProvider(new CustomCacheKeyProvider())
+    ->debounce($job, 10);
+```
+
+If you provide a closure, it may only be be hot-swapped:
+
+```php
+$debouncer
+    ->usingCacheKeyProvider(fn () => 'my custom key')
+    ->debounce($job, 10);
+```
+
+Closure providers automatically have their value prefixed by the configured `cache_prefix`. To override this behaviour, implement a class-based provider that accepts a closure in its constructor, then calls it in its `getKey` method.
 
 ### Unique identifier provider
-Each time a debounced job is dispatched, a unique identifier is stored against the cache key for the job. When the wait time expires, if that identifier matches the value inserted, the debouncer knows that no more recent instances of the job have been dispatched, and therefore it is safe to dispatch it.
 
-The default implementation produces a UUID v4 for each dispatch. If you need to override this you may do so via the config. As with the cache key provider, your class must implement  `Mpbarlow\LaravelQueueDebouncer\Contracts\UniqueIdentifierProvider`.
+Each time a debounced job is dispatched, a unique identifier is stored against the cache key for the job. When the wait time expires, if that identifier matches the value of the current job, the debouncer knows that no more recent instances of the job have been dispatched, and therefore it is safe to dispatch it.
+
+The default implementation produces a UUID v4 for each dispatch. If you need to override this you may do so in the same manner as cache key providers, globally registering a class under the `unique_identifier_provider` key in the config, or hot-swapping using the `usingUniqueIdentifierProvider` method:
+
+```php
+$debouncer
+    ->usingUniqueIdentifierProvider(new CustomUniqueIdentifierProvider())
+    ->debounce($job, 10);
+
+$debouncer
+    ->usingUniqueIdentifierProvider(fn () => 'my custom identifier')
+    ->debounce($job, 10);
+```
+
+Class-based providers should implement `Mpbarlow\LaravelQueueDebouncer\Contracts\UniqueIdentifierProvider`.
 
 ## Licence
+
 This package is open-source software provided under the [The MIT License](https://opensource.org/licenses/MIT).

--- a/src/Contracts/CacheKeyProvider.php
+++ b/src/Contracts/CacheKeyProvider.php
@@ -5,12 +5,11 @@ namespace Mpbarlow\LaravelQueueDebouncer\Contracts;
 
 
 use Closure;
-use Illuminate\Foundation\Bus\Dispatchable;
 
 interface CacheKeyProvider
 {
     /**
-     * @param Dispatchable|Closure $job
+     * @param \Illuminate\Foundation\Bus\Dispatchable|\Illuminate\Foundation\Bus\PendingChain|\Illuminate\Bus\PendingBatch|Closure $job
      * @return string
      */
     public function getKey($job): string;

--- a/src/Contracts/CacheKeyProvider.php
+++ b/src/Contracts/CacheKeyProvider.php
@@ -9,7 +9,7 @@ use Closure;
 interface CacheKeyProvider
 {
     /**
-     * @param \Illuminate\Foundation\Bus\Dispatchable|\Illuminate\Foundation\Bus\PendingChain|\Illuminate\Bus\PendingBatch|Closure $job
+     * @param \Illuminate\Foundation\Bus\Dispatchable|\Illuminate\Foundation\Bus\PendingChain|Closure $job
      * @return string
      */
     public function getKey($job): string;

--- a/src/Debouncer.php
+++ b/src/Debouncer.php
@@ -5,11 +5,8 @@ namespace Mpbarlow\LaravelQueueDebouncer;
 
 
 use Closure;
-use DateInterval;
-use DateTimeInterface;
 use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Facades\Cache;
 use Mpbarlow\LaravelQueueDebouncer\Contracts\CacheKeyProvider;
 use Mpbarlow\LaravelQueueDebouncer\Contracts\UniqueIdentifierProvider;
@@ -34,10 +31,24 @@ class Debouncer
         $this->factory = $factory;
     }
 
+    public function usingCacheKeyProvider(CacheKeyProvider $provider): self
+    {
+        $this->keyProvider = $provider;
+
+        return $this;
+    }
+
+    public function usingUniqueIdentifierProvider(UniqueIdentifierProvider $provider): self
+    {
+        $this->idProvider = $provider;
+
+        return $this;
+    }
+
     /**
-     * @param Dispatchable|Closure $job
-     * @param DateTimeInterface|DateInterval|int|null $wait
-     * @return PendingDispatch
+     * @param Dispatchable|\Illuminate\Foundation\Bus\PendingChain|\Illuminate\Bus\PendingBatch|Closure $job
+     * @param \DateTimeInterface|\DateInterval|int|null $wait
+     * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
     public function __invoke($job, $wait)
     {
@@ -52,9 +63,9 @@ class Debouncer
     }
 
     /**
-     * @param Dispatchable|Closure $job
-     * @param DateTimeInterface|DateInterval|int|null $wait
-     * @return PendingDispatch
+     * @param Dispatchable|\Illuminate\Foundation\Bus\PendingChain|\Illuminate\Bus\PendingBatch|Closure $job
+     * @param \DateTimeInterface|\DateInterval|int|null $wait
+     * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
     public function debounce($job, $wait)
     {

--- a/src/DispatcherFactory.php
+++ b/src/DispatcherFactory.php
@@ -5,10 +5,11 @@ namespace Mpbarlow\LaravelQueueDebouncer;
 
 
 use Closure;
-use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Support\Facades\Cache;
 
 use function dispatch;
+use function get_class;
+use function in_array;
 
 class DispatcherFactory
 {
@@ -18,7 +19,7 @@ class DispatcherFactory
      * If we used a class as the dispatcher, we would have to check whether the job is a closure ourselves, and
      * serialise it if it was.
      *
-     * @param Dispatchable|Closure $job
+     * @param \Illuminate\Foundation\Bus\Dispatchable|\Illuminate\Foundation\Bus\PendingChain|\Illuminate\Bus\PendingBatch|Closure $job
      * @param string $key
      * @param string $identifier
      * @return Closure
@@ -29,8 +30,25 @@ class DispatcherFactory
             if (Cache::get($key) == $identifier) {
                 Cache::forget($key);
 
-                dispatch($job);
+                if ($this->hasDispatchMethod($job)) {
+                    $job->dispatch();
+                } else {
+                    dispatch($job);
+                }
             }
         };
+    }
+
+    /**
+     * @param \Illuminate\Foundation\Bus\Dispatchable|\Illuminate\Foundation\Bus\PendingChain|\Illuminate\Bus\PendingBatch|Closure $job
+     * @return bool
+     */
+    protected function hasDispatchMethod($job)
+    {
+        // PendingBatch is not available in Laravel < 8.0, hence the string comparison.
+        return in_array(
+            get_class($job),
+            ['\Illuminate\Foundation\Bus\PendingChain', '\Illuminate\Bus\PendingBatch']
+        );
     }
 }

--- a/src/Facade/Debouncer.php
+++ b/src/Facade/Debouncer.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @see \Mpbarlow\LaravelQueueDebouncer\Debouncer
- * @method static \Illuminate\Foundation\Bus\PendingDispatch debounce(\Illuminate\Foundation\Bus\Dispatchable|\Closure $job, \DateTimeInterface|\DateInterval|int|null $wait)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch debounce(\Illuminate\Foundation\Bus\Dispatchable|\Illuminate\Foundation\Bus\PendingChain|\Illuminate\Bus\PendingBatch|\Closure $job, \DateTimeInterface|\DateInterval|int|null $wait)
  */
 class Debouncer extends Facade
 {

--- a/src/Facade/Debouncer.php
+++ b/src/Facade/Debouncer.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @see \Mpbarlow\LaravelQueueDebouncer\Debouncer
- * @method static \Illuminate\Foundation\Bus\PendingDispatch debounce(\Illuminate\Foundation\Bus\Dispatchable|\Illuminate\Foundation\Bus\PendingChain|\Illuminate\Bus\PendingBatch|\Closure $job, \DateTimeInterface|\DateInterval|int|null $wait)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch debounce(\Illuminate\Foundation\Bus\Dispatchable|\Illuminate\Foundation\Bus\PendingChain|\Closure $job, \DateTimeInterface|\DateInterval|int|null $wait)
  */
 class Debouncer extends Facade
 {

--- a/src/Support/ClosureCacheKeyProvider.php
+++ b/src/Support/ClosureCacheKeyProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace Mpbarlow\LaravelQueueDebouncer\Support;
+
+
+use Closure;
+use Mpbarlow\LaravelQueueDebouncer\Contracts\CacheKeyProvider as CacheKeyProviderContract;
+
+use function config;
+
+class ClosureCacheKeyProvider implements CacheKeyProviderContract
+{
+    protected $provider;
+
+    public function __construct(Closure $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    public function getKey($job): string
+    {
+        return config('queue_debouncer.cache_prefix') . ':' . ($this->provider)($job);
+    }
+}

--- a/src/Support/ClosureUniqueIdentifierProvider.php
+++ b/src/Support/ClosureUniqueIdentifierProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Mpbarlow\LaravelQueueDebouncer\Support;
+
+
+use Closure;
+use Mpbarlow\LaravelQueueDebouncer\Contracts\UniqueIdentifierProvider as UniqueIdentifierProviderContract;
+
+class ClosureUniqueIdentifierProvider implements UniqueIdentifierProviderContract
+{
+    protected $provider;
+
+    public function __construct(Closure $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    public function getIdentifier(): string
+    {
+        return ($this->provider)();
+    }
+}

--- a/src/Support/ParameterAwareCacheKeyProvider.php
+++ b/src/Support/ParameterAwareCacheKeyProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Mpbarlow\LaravelQueueDebouncer\Support;
+
+
+use Mpbarlow\LaravelQueueDebouncer\Contracts\CacheKeyProvider as CacheKeyProviderContract;
+
+use function config;
+use function sha1;
+
+class ParameterAwareCacheKeyProvider implements CacheKeyProviderContract
+{
+    public function getKey($job): string
+    {
+        return config('queue_debouncer.cache_prefix') . ':' . sha1(\Opis\Closure\serialize($job));
+    }
+}

--- a/src/Support/SerializingCacheKeyProvider.php
+++ b/src/Support/SerializingCacheKeyProvider.php
@@ -9,7 +9,7 @@ use Mpbarlow\LaravelQueueDebouncer\Contracts\CacheKeyProvider as CacheKeyProvide
 use function config;
 use function sha1;
 
-class ParameterAwareCacheKeyProvider implements CacheKeyProviderContract
+class SerializingCacheKeyProvider implements CacheKeyProviderContract
 {
     public function getKey($job): string
     {

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -1,14 +1,12 @@
 <?php
 
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Foundation\Bus\PendingDispatch;
 use Mpbarlow\LaravelQueueDebouncer\Debouncer;
 
 if (! function_exists('debounce')) {
     /**
-     * @param Dispatchable|Closure $job
+     * @param \Illuminate\Foundation\Bus\Dispatchable|\Illuminate\Foundation\Bus\PendingChain|\Illuminate\Bus\PendingBatch|Closure $job
      * @param DateTimeInterface|DateInterval|int|null $wait
-     * @return PendingDispatch
+     * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
     function debounce($job, $wait)
     {

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -4,7 +4,7 @@ use Mpbarlow\LaravelQueueDebouncer\Debouncer;
 
 if (! function_exists('debounce')) {
     /**
-     * @param \Illuminate\Foundation\Bus\Dispatchable|\Illuminate\Foundation\Bus\PendingChain|\Illuminate\Bus\PendingBatch|Closure $job
+     * @param \Illuminate\Foundation\Bus\Dispatchable|\Illuminate\Foundation\Bus\PendingChain|Closure $job
      * @param DateTimeInterface|DateInterval|int|null $wait
      * @return \Illuminate\Foundation\Bus\PendingDispatch
      */

--- a/tests/CacheKeyProviderTest.php
+++ b/tests/CacheKeyProviderTest.php
@@ -4,33 +4,14 @@
 namespace Mpbarlow\LaravelQueueDebouncer\Tests;
 
 
-use Illuminate\Foundation\Bus\Dispatchable;
 use Mpbarlow\LaravelQueueDebouncer\Support\CacheKeyProvider;
-use ReflectionFunction;
+use Mpbarlow\LaravelQueueDebouncer\Tests\Support\DummyJob;
 
-use function sha1;
 use function strlen;
 use function substr;
 
 class CacheKeyProviderTest extends TestCase
 {
-    /** @test */
-    public function it_applies_the_cache_prefix()
-    {
-        $this->app['config']->set('queue_debouncer.cache_prefix', $prefix = '__PREFIX__');
-
-        $provider = new CacheKeyProvider();
-
-        $closureJob = function () {};
-
-        $this->assertEquals($prefix . ':' . DummyJob::class, $provider->getKey(new DummyJob()));
-
-        $this->assertEquals(
-            $prefix . ':' . sha1((string)(new ReflectionFunction($closureJob))),
-            $provider->getKey($closureJob)
-        );
-    }
-
     /** @test */
     public function it_uses_the_class_name_for_job_classes()
     {
@@ -44,37 +25,4 @@ class CacheKeyProviderTest extends TestCase
             substr($provider->getKey(new DummyJob()), strlen($prefix) + 1)
         );
     }
-
-    /** @test */
-    public function it_generates_a_unique_key_for_closures()
-    {
-        $provider = new CacheKeyProvider();
-
-        $job1 = function () {};
-        $job2 = function () {};
-
-        $key1 = $provider->getKey($job1);
-        $key2 = $provider->getKey($job2);
-
-        // Assert different closures result in different keys.
-        $this->assertNotEquals($key1, $key2);
-    }
-
-    /** @test */
-    public function it_generates_a_consistent_key_for_closures()
-    {
-        $provider = new CacheKeyProvider();
-
-        $job = function () {};
-
-        $key1 = $provider->getKey($job);
-        $key2 = $provider->getKey($job);
-
-        // Assert the same closure results in the same key each time.
-        $this->assertEquals($key1, $key2);
-    }
-}
-
-class DummyJob {
-    use Dispatchable;
 }

--- a/tests/ClosureCacheKeyProviderTest.php
+++ b/tests/ClosureCacheKeyProviderTest.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace Mpbarlow\LaravelQueueDebouncer\Tests;
+
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
+use Mpbarlow\LaravelQueueDebouncer\Debouncer;
+
+use const PHP_INT_MAX;
+
+class ClosureCacheKeyProviderTest extends TestCase
+{
+    /** @test */
+    public function it_calls_the_provided_closure()
+    {
+        Bus::fake();
+
+        $prefix = '__PREFIX__';
+        $this->app['config']->set('queue_debouncer.cache_prefix', $prefix);
+
+        $key = '__KEY__';
+
+        $closure = function () use ($key) {
+            return $key;
+        };
+
+        $debouncer = $this->app->make(Debouncer::class)->usingCacheKeyProvider($closure);
+
+        $debouncer->debounce(function () {}, PHP_INT_MAX);
+
+        $this->assertTrue(
+            Cache::has("{$prefix}:{$key}")
+        );
+    }
+}

--- a/tests/ClosureUniqueIdentifierProviderTest.php
+++ b/tests/ClosureUniqueIdentifierProviderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+
+namespace Mpbarlow\LaravelQueueDebouncer\Tests;
+
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
+use Mpbarlow\LaravelQueueDebouncer\Debouncer;
+
+use const PHP_INT_MAX;
+
+class ClosureUniqueIdentifierProviderTest extends TestCase
+{
+    /** @test */
+    public function it_calls_the_provided_closure()
+    {
+        Bus::fake();
+
+        $prefix = '__PREFIX__';
+        $this->app['config']->set('queue_debouncer.cache_prefix', $prefix);
+
+        $key = '__KEY__';
+
+        $closure = function () use ($key) {
+            return $key;
+        };
+
+        $debouncer = $this->app->make(Debouncer::class)
+            ->usingCacheKeyProvider($closure)
+            ->usingUniqueIdentifierProvider($closure);
+
+        $debouncer->debounce(function () {}, PHP_INT_MAX);
+
+        $this->assertSame(
+            $key,
+            Cache::get("{$prefix}:{$key}")
+        );
+    }
+}

--- a/tests/ParameterAwareCacheKeyProviderTest.php
+++ b/tests/ParameterAwareCacheKeyProviderTest.php
@@ -1,0 +1,90 @@
+<?php
+
+
+namespace Mpbarlow\LaravelQueueDebouncer\Tests;
+
+
+use Illuminate\Support\Facades\Bus;
+use Mpbarlow\LaravelQueueDebouncer\Support\ParameterAwareCacheKeyProvider;
+use Mpbarlow\LaravelQueueDebouncer\Tests\Support\DummyJob;
+use Mpbarlow\LaravelQueueDebouncer\Tests\Support\DummyJobWithArgs;
+
+use function class_exists;
+
+class ParameterAwareCacheKeyProviderTest extends TestCase
+{
+    /** @test */
+    public function it_generates_the_same_key_when_objects_are_equal()
+    {
+        $provider = new ParameterAwareCacheKeyProvider();
+
+        $job1 = new DummyJobWithArgs('hello');
+        $job2 = new DummyJobWithArgs('hello');
+
+        $this->assertSame(
+            $provider->getKey($job1),
+            $provider->getKey($job2)
+        );
+    }
+
+    /** @test */
+    public function it_generates_a_unique_key_when_objects_are_not_equal()
+    {
+        $provider = new ParameterAwareCacheKeyProvider();
+
+        $job1 = new DummyJobWithArgs('hello');
+        $job2 = new DummyJobWithArgs('world');
+
+        $this->assertNotSame(
+            $provider->getKey($job1),
+            $provider->getKey($job2)
+        );
+    }
+
+    /** @test */
+    public function it_allows_for_chains_to_be_debounced()
+    {
+        $provider = new ParameterAwareCacheKeyProvider();
+
+        $chain1 = DummyJob::withChain([new DummyJobWithArgs('hello')]);
+        $chain2 = DummyJob::withChain([new DummyJobWithArgs('hello')]);
+
+        $chain3 = DummyJob::withChain([new DummyJobWithArgs('world')]);
+
+        $this->assertSame(
+            $provider->getKey($chain1),
+            $provider->getKey($chain2)
+        );
+
+        $this->assertNotSame(
+            $provider->getKey($chain1),
+            $provider->getKey($chain3)
+        );
+    }
+
+    /** @test */
+    public function it_allows_for_batches_to_be_debounced()
+    {
+        if (! class_exists('\Illuminate\Bus\PendingBatch')) {
+            $this->markTestSkipped('[\Illuminate\Bus\PendingBatch] is only available on Laravel >= 8.0.');
+            return;
+        }
+
+        $provider = new ParameterAwareCacheKeyProvider();
+
+        $batch1 = Bus::batch([new DummyJobWithArgs('hello')]);
+        $batch2 = Bus::batch([new DummyJobWithArgs('hello')]);
+
+        $batch3 = Bus::batch([new DummyJobWithArgs('world')]);
+
+        $this->assertSame(
+            $provider->getKey($batch1),
+            $provider->getKey($batch2)
+        );
+
+        $this->assertNotSame(
+            $provider->getKey($batch1),
+            $provider->getKey($batch3)
+        );
+    }
+}

--- a/tests/ProviderHotSwapTest.php
+++ b/tests/ProviderHotSwapTest.php
@@ -1,0 +1,56 @@
+<?php
+
+
+namespace Mpbarlow\LaravelQueueDebouncer\Tests;
+
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
+use Mpbarlow\LaravelQueueDebouncer\Debouncer;
+use Mpbarlow\LaravelQueueDebouncer\Tests\Support\HotSwappedCacheKeyProvider;
+use Mpbarlow\LaravelQueueDebouncer\Tests\Support\HotSwappedIdentifierProvider;
+
+class ProviderHotSwapTest extends TestCase
+{
+    /** @test */
+    public function the_cache_key_provider_can_be_hot_swapped()
+    {
+        Bus::fake();
+
+        $debouncer = $this->app->make(Debouncer::class);
+
+        $this->assertFalse(
+            Cache::has(HotSwappedCacheKeyProvider::KEY)
+        );
+
+        $debouncer
+            ->usingCacheKeyProvider(new HotSwappedCacheKeyProvider())
+            ->debounce(function () {}, 0);
+
+        $this->assertTrue(
+            Cache::has(HotSwappedCacheKeyProvider::KEY)
+        );
+    }
+
+    /** @test */
+    public function the_identifier_provider_can_be_hot_swapped()
+    {
+        Bus::fake();
+
+        $debouncer = $this->app->make(Debouncer::class);
+
+        $this->assertFalse(
+            Cache::has(HotSwappedCacheKeyProvider::KEY)
+        );
+
+        $debouncer
+            ->usingCacheKeyProvider(new HotSwappedCacheKeyProvider())
+            ->usingUniqueIdentifierProvider(new HotSwappedIdentifierProvider())
+            ->debounce(function () {}, 0);
+
+        $this->assertSame(
+            HotSwappedIdentifierProvider::IDENTIFIER,
+            Cache::get(HotSwappedCacheKeyProvider::KEY)
+        );
+    }
+}

--- a/tests/SerializingCacheKeyProviderTest.php
+++ b/tests/SerializingCacheKeyProviderTest.php
@@ -4,19 +4,16 @@
 namespace Mpbarlow\LaravelQueueDebouncer\Tests;
 
 
-use Illuminate\Support\Facades\Bus;
-use Mpbarlow\LaravelQueueDebouncer\Support\ParameterAwareCacheKeyProvider;
+use Mpbarlow\LaravelQueueDebouncer\Support\SerializingCacheKeyProvider;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\DummyJob;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\DummyJobWithArgs;
 
-use function class_exists;
-
-class ParameterAwareCacheKeyProviderTest extends TestCase
+class SerializingCacheKeyProviderTest extends TestCase
 {
     /** @test */
     public function it_generates_the_same_key_when_objects_are_equal()
     {
-        $provider = new ParameterAwareCacheKeyProvider();
+        $provider = new SerializingCacheKeyProvider();
 
         $job1 = new DummyJobWithArgs('hello');
         $job2 = new DummyJobWithArgs('hello');
@@ -30,7 +27,7 @@ class ParameterAwareCacheKeyProviderTest extends TestCase
     /** @test */
     public function it_generates_a_unique_key_when_objects_are_not_equal()
     {
-        $provider = new ParameterAwareCacheKeyProvider();
+        $provider = new SerializingCacheKeyProvider();
 
         $job1 = new DummyJobWithArgs('hello');
         $job2 = new DummyJobWithArgs('world');
@@ -44,7 +41,7 @@ class ParameterAwareCacheKeyProviderTest extends TestCase
     /** @test */
     public function it_allows_for_chains_to_be_debounced()
     {
-        $provider = new ParameterAwareCacheKeyProvider();
+        $provider = new SerializingCacheKeyProvider();
 
         $chain1 = DummyJob::withChain([new DummyJobWithArgs('hello')]);
         $chain2 = DummyJob::withChain([new DummyJobWithArgs('hello')]);
@@ -59,32 +56,6 @@ class ParameterAwareCacheKeyProviderTest extends TestCase
         $this->assertNotSame(
             $provider->getKey($chain1),
             $provider->getKey($chain3)
-        );
-    }
-
-    /** @test */
-    public function it_allows_for_batches_to_be_debounced()
-    {
-        if (! class_exists('\Illuminate\Bus\PendingBatch')) {
-            $this->markTestSkipped('[\Illuminate\Bus\PendingBatch] is only available on Laravel >= 8.0.');
-            return;
-        }
-
-        $provider = new ParameterAwareCacheKeyProvider();
-
-        $batch1 = Bus::batch([new DummyJobWithArgs('hello')]);
-        $batch2 = Bus::batch([new DummyJobWithArgs('hello')]);
-
-        $batch3 = Bus::batch([new DummyJobWithArgs('world')]);
-
-        $this->assertSame(
-            $provider->getKey($batch1),
-            $provider->getKey($batch2)
-        );
-
-        $this->assertNotSame(
-            $provider->getKey($batch1),
-            $provider->getKey($batch3)
         );
     }
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -6,6 +6,8 @@ namespace Mpbarlow\LaravelQueueDebouncer\Tests;
 
 use Mpbarlow\LaravelQueueDebouncer\Contracts\CacheKeyProvider as CacheKeyProviderContract;
 use Mpbarlow\LaravelQueueDebouncer\Contracts\UniqueIdentifierProvider as UniqueIdentifierProviderContract;
+use Mpbarlow\LaravelQueueDebouncer\Tests\Support\CustomCacheKeyProvider;
+use Mpbarlow\LaravelQueueDebouncer\Tests\Support\CustomUniqueIdentifierProvider;
 
 class ServiceProviderTest extends TestCase
 {

--- a/tests/SharedCacheKeyProviderTest.php
+++ b/tests/SharedCacheKeyProviderTest.php
@@ -1,0 +1,128 @@
+<?php
+
+
+namespace Mpbarlow\LaravelQueueDebouncer\Tests;
+
+
+use Illuminate\Support\Facades\Bus;
+use Mpbarlow\LaravelQueueDebouncer\Support\CacheKeyProvider;
+use Mpbarlow\LaravelQueueDebouncer\Support\ParameterAwareCacheKeyProvider;
+use Mpbarlow\LaravelQueueDebouncer\Tests\Support\DummyJob;
+
+use function class_exists;
+use function strpos;
+
+class SharedCacheKeyProviderTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider cacheKeyProviderProvider
+     */
+    public function it_applies_the_cache_prefix_to_classes($provider)
+    {
+        $this->app['config']->set('queue_debouncer.cache_prefix', $prefix = '__PREFIX__');
+
+        $job = new DummyJob();
+
+        $this->assertSame(
+            0,
+            strpos($provider->getKey($job), $prefix)
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider cacheKeyProviderProvider
+     */
+    public function it_applies_the_cache_prefix_to_chains($provider)
+    {
+        $this->app['config']->set('queue_debouncer.cache_prefix', $prefix = '__PREFIX__');
+
+        $job = DummyJob::withChain([new DummyJob()]);
+
+        $this->assertSame(
+            0,
+            strpos($provider->getKey($job), $prefix)
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider cacheKeyProviderProvider
+     */
+    public function it_applies_the_cache_prefix_to_batches($provider)
+    {
+        if (! class_exists('\Illuminate\Bus\PendingBatch')) {
+            $this->markTestSkipped('[\Illuminate\Bus\PendingBatch] is only available on Laravel >= 8.0.');
+            return;
+        }
+
+        $this->app['config']->set('queue_debouncer.cache_prefix', $prefix = '__PREFIX__');
+
+        $job = Bus::batch([new DummyJob()]);
+
+        $this->assertSame(
+            0,
+            strpos($provider->getKey($job), $prefix)
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider cacheKeyProviderProvider
+     */
+    public function it_applies_the_cache_prefix_to_closures($provider)
+    {
+        $this->app['config']->set('queue_debouncer.cache_prefix', $prefix = '__PREFIX__');
+
+        $job = function () {
+        };
+
+        $this->assertSame(
+            0,
+            strpos($provider->getKey($job), $prefix)
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider cacheKeyProviderProvider
+     */
+    public function it_generates_a_unique_key_for_closures($provider)
+    {
+        $job1 = function () {
+        };
+        $job2 = function () {
+        };
+
+        $key1 = $provider->getKey($job1);
+        $key2 = $provider->getKey($job2);
+
+        // Assert different closures result in different keys.
+        $this->assertNotEquals($key1, $key2);
+    }
+
+    /**
+     * @test
+     * @dataProvider cacheKeyProviderProvider
+     */
+    public function it_generates_a_consistent_key_for_closures($provider)
+    {
+        $job = function () {
+        };
+
+        $key1 = $provider->getKey($job);
+        $key2 = $provider->getKey($job);
+
+        // Assert the same closure results in the same key each time.
+        $this->assertEquals($key1, $key2);
+    }
+
+    public function cacheKeyProviderProvider()
+    {
+        return [
+            [new CacheKeyProvider()],
+            [new ParameterAwareCacheKeyProvider()]
+        ];
+    }
+}

--- a/tests/SharedCacheKeyProviderTest.php
+++ b/tests/SharedCacheKeyProviderTest.php
@@ -4,12 +4,10 @@
 namespace Mpbarlow\LaravelQueueDebouncer\Tests;
 
 
-use Illuminate\Support\Facades\Bus;
 use Mpbarlow\LaravelQueueDebouncer\Support\CacheKeyProvider;
-use Mpbarlow\LaravelQueueDebouncer\Support\ParameterAwareCacheKeyProvider;
+use Mpbarlow\LaravelQueueDebouncer\Support\SerializingCacheKeyProvider;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\DummyJob;
 
-use function class_exists;
 use function strpos;
 
 class SharedCacheKeyProviderTest extends TestCase
@@ -39,27 +37,6 @@ class SharedCacheKeyProviderTest extends TestCase
         $this->app['config']->set('queue_debouncer.cache_prefix', $prefix = '__PREFIX__');
 
         $job = DummyJob::withChain([new DummyJob()]);
-
-        $this->assertSame(
-            0,
-            strpos($provider->getKey($job), $prefix)
-        );
-    }
-
-    /**
-     * @test
-     * @dataProvider cacheKeyProviderProvider
-     */
-    public function it_applies_the_cache_prefix_to_batches($provider)
-    {
-        if (! class_exists('\Illuminate\Bus\PendingBatch')) {
-            $this->markTestSkipped('[\Illuminate\Bus\PendingBatch] is only available on Laravel >= 8.0.');
-            return;
-        }
-
-        $this->app['config']->set('queue_debouncer.cache_prefix', $prefix = '__PREFIX__');
-
-        $job = Bus::batch([new DummyJob()]);
 
         $this->assertSame(
             0,
@@ -122,7 +99,7 @@ class SharedCacheKeyProviderTest extends TestCase
     {
         return [
             [new CacheKeyProvider()],
-            [new ParameterAwareCacheKeyProvider()]
+            [new SerializingCacheKeyProvider()]
         ];
     }
 }

--- a/tests/Support/CustomCacheKeyProvider.php
+++ b/tests/Support/CustomCacheKeyProvider.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Mpbarlow\LaravelQueueDebouncer\Tests\Support;
+
+
+use Mpbarlow\LaravelQueueDebouncer\Support\CacheKeyProvider;
+
+class CustomCacheKeyProvider extends CacheKeyProvider
+{
+}

--- a/tests/Support/CustomUniqueIdentifierProvider.php
+++ b/tests/Support/CustomUniqueIdentifierProvider.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Mpbarlow\LaravelQueueDebouncer\Tests\Support;
+
+
+use Mpbarlow\LaravelQueueDebouncer\Support\UniqueIdentifierProvider;
+
+class CustomUniqueIdentifierProvider extends UniqueIdentifierProvider
+{
+}

--- a/tests/Support/DummyJob.php
+++ b/tests/Support/DummyJob.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Mpbarlow\LaravelQueueDebouncer\Tests\Support;
+
+
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class DummyJob
+{
+    use Dispatchable;
+
+    public function handle()
+    {
+        //
+    }
+}

--- a/tests/Support/DummyJob.php
+++ b/tests/Support/DummyJob.php
@@ -4,11 +4,12 @@
 namespace Mpbarlow\LaravelQueueDebouncer\Tests\Support;
 
 
+use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Bus\Dispatchable;
 
 class DummyJob
 {
-    use Dispatchable;
+    use Dispatchable, Queueable;
 
     public function handle()
     {

--- a/tests/Support/DummyJobWithArgs.php
+++ b/tests/Support/DummyJobWithArgs.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Mpbarlow\LaravelQueueDebouncer\Tests\Support;
+
+
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class DummyJobWithArgs
+{
+    use Dispatchable;
+
+    protected $arg;
+
+    public function __construct($arg)
+    {
+        $this->arg = $arg;
+    }
+
+    public function handle()
+    {
+        //
+    }
+}

--- a/tests/Support/DummyJobWithArgs.php
+++ b/tests/Support/DummyJobWithArgs.php
@@ -4,11 +4,12 @@
 namespace Mpbarlow\LaravelQueueDebouncer\Tests\Support;
 
 
+use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Bus\Dispatchable;
 
 class DummyJobWithArgs
 {
-    use Dispatchable;
+    use Dispatchable, Queueable;
 
     protected $arg;
 

--- a/tests/Support/HotSwappedCacheKeyProvider.php
+++ b/tests/Support/HotSwappedCacheKeyProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Mpbarlow\LaravelQueueDebouncer\Tests\Support;
+
+
+use Mpbarlow\LaravelQueueDebouncer\Contracts\CacheKeyProvider;
+
+class HotSwappedCacheKeyProvider implements CacheKeyProvider
+{
+    public const KEY = '__KEY__';
+
+    public function getKey($job): string
+    {
+        return self::KEY;
+    }
+}

--- a/tests/Support/HotSwappedIdentifierProvider.php
+++ b/tests/Support/HotSwappedIdentifierProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Mpbarlow\LaravelQueueDebouncer\Tests\Support;
+
+
+use Mpbarlow\LaravelQueueDebouncer\Contracts\UniqueIdentifierProvider;
+
+class HotSwappedIdentifierProvider implements UniqueIdentifierProvider
+{
+    public const IDENTIFIER = '__IDENTIFIER__';
+
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,8 +6,6 @@ namespace Mpbarlow\LaravelQueueDebouncer\Tests;
 
 use Mpbarlow\LaravelQueueDebouncer\Facade\Debouncer;
 use Mpbarlow\LaravelQueueDebouncer\ServiceProvider;
-use Mpbarlow\LaravelQueueDebouncer\Support\CacheKeyProvider;
-use Mpbarlow\LaravelQueueDebouncer\Support\UniqueIdentifierProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -25,6 +23,3 @@ class TestCase extends \Orchestra\Testbench\TestCase
         ];
     }
 }
-
-class CustomCacheKeyProvider extends CacheKeyProvider {}
-class CustomUniqueIdentifierProvider extends UniqueIdentifierProvider {}


### PR DESCRIPTION
Addresses #3 by adding support for debouncing `PendingChain` and by adding `SerializingCacheKeyProvider` to distinguish between chains.

Addresses #4 by adding `SerializingCacheKeyProvider` so that jobs with different parameters are considered different and can be debounced independently.

Adds support for overriding behaviour on the fly with closures or custom provider classes.