### PR TITLE
Allow php 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "laravel/framework": "^6.0|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
Modified composer.json to allow php 8.0. 

Unittests passes