### PR TITLE
PHP 8.4 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.1",
         "laravel/framework": "^10.0|^11.0",
-        "laravel/serializable-closure": "^2.0"
+        "laravel/serializable-closure": "^1.3|^2.0"
     },
     "require-dev": {
         "orchestra/testbench": "^9.0",

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
-        "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "opis/closure": "^3.6"
+        "php": "^8.1",
+        "laravel/framework": "^10.0|^11.0",
+        "laravel/serializable-closure": "^2.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",
-        "phpunit/phpunit": "^8.0|^9.0"
+        "orchestra/testbench": "^9.0",
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>

--- a/src/Support/SerializingCacheKeyProvider.php
+++ b/src/Support/SerializingCacheKeyProvider.php
@@ -4,6 +4,8 @@
 namespace Mpbarlow\LaravelQueueDebouncer\Support;
 
 
+use Closure;
+use Laravel\SerializableClosure\SerializableClosure;
 use Mpbarlow\LaravelQueueDebouncer\Contracts\CacheKeyProvider as CacheKeyProviderContract;
 
 use function config;
@@ -13,6 +15,7 @@ class SerializingCacheKeyProvider implements CacheKeyProviderContract
 {
     public function getKey($job): string
     {
-        return config('queue_debouncer.cache_prefix') . ':' . sha1(\Opis\Closure\serialize($job));
+        return config('queue_debouncer.cache_prefix').':'.
+            sha1(serialize($job instanceof Closure ? new SerializableClosure($job) : $job));
     }
 }

--- a/tests/CacheKeyProviderTest.php
+++ b/tests/CacheKeyProviderTest.php
@@ -7,12 +7,13 @@ namespace Mpbarlow\LaravelQueueDebouncer\Tests;
 use Mpbarlow\LaravelQueueDebouncer\Support\CacheKeyProvider;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\DummyJob;
 
+use PHPUnit\Framework\Attributes\Test;
 use function strlen;
 use function substr;
 
 class CacheKeyProviderTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_uses_the_class_name_for_job_classes()
     {
         $this->app['config']->set('queue_debouncer.cache_prefix', $prefix = '__PREFIX__');

--- a/tests/ClosureCacheKeyProviderTest.php
+++ b/tests/ClosureCacheKeyProviderTest.php
@@ -8,11 +8,12 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Cache;
 use Mpbarlow\LaravelQueueDebouncer\Debouncer;
 
+use PHPUnit\Framework\Attributes\Test;
 use const PHP_INT_MAX;
 
 class ClosureCacheKeyProviderTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_calls_the_provided_closure()
     {
         Bus::fake();

--- a/tests/ClosureUniqueIdentifierProviderTest.php
+++ b/tests/ClosureUniqueIdentifierProviderTest.php
@@ -8,11 +8,12 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Cache;
 use Mpbarlow\LaravelQueueDebouncer\Debouncer;
 
+use PHPUnit\Framework\Attributes\Test;
 use const PHP_INT_MAX;
 
 class ClosureUniqueIdentifierProviderTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_calls_the_provided_closure()
     {
         Bus::fake();

--- a/tests/DebounceTest.php
+++ b/tests/DebounceTest.php
@@ -14,6 +14,8 @@ use Mpbarlow\LaravelQueueDebouncer\Support\SerializingCacheKeyProvider;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\CustomCacheKeyProvider;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\CustomUniqueIdentifierProvider;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\DummyJob;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use ReflectionFunction;
 
 use function array_shift;
@@ -22,7 +24,7 @@ use const PHP_INT_MAX;
 
 class DebounceTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_injects_the_configured_cache_key_provider_and_unique_identifier_provider()
     {
         Bus::fake();
@@ -46,10 +48,8 @@ class DebounceTest extends TestCase
         }, PHP_INT_MAX);
     }
 
-    /**
-     * @test
-     * @dataProvider jobProvider
-     */
+    #[Test]
+    #[DataProvider('jobProvider')]
     public function it_debounces_jobs($job, $expectedDispatch, $keyProvider)
     {
         // So this is pretty tricky to test. It's a job that dispatches another job, so when we're faking the bus we
@@ -108,7 +108,7 @@ class DebounceTest extends TestCase
         $this->assertNull(Cache::get($key));
     }
 
-    public function jobProvider(): array
+    public static function jobProvider(): array
     {
         // Closures and standard classes should work with both included cache key providers.
         // Chains only work with the serialisation-based key provider.

--- a/tests/DebounceableTest.php
+++ b/tests/DebounceableTest.php
@@ -8,11 +8,12 @@ use Mpbarlow\LaravelQueueDebouncer\Debouncer;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\DummyJobWithArgsAndTrait;
 use Illuminate\Support\Facades\Bus;
 
+use PHPUnit\Framework\Attributes\Test;
 use function debounce;
 
 class DebounceableTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_uses_the_new_trait_to_dispatch()
     {
         Bus::fake();

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -6,10 +6,11 @@ namespace Mpbarlow\LaravelQueueDebouncer\Tests;
 
 use Mpbarlow\LaravelQueueDebouncer\Debouncer;
 use Mpbarlow\LaravelQueueDebouncer\Facade\Debouncer as Facade;
+use PHPUnit\Framework\Attributes\Test;
 
 class FacadeTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_passes_calls_to_the_container()
     {
         $this->mock(Debouncer::class, function ($mock) {

--- a/tests/GlobalFunctionTest.php
+++ b/tests/GlobalFunctionTest.php
@@ -6,11 +6,12 @@ namespace Mpbarlow\LaravelQueueDebouncer\Tests;
 
 use Mpbarlow\LaravelQueueDebouncer\Debouncer;
 
+use PHPUnit\Framework\Attributes\Test;
 use function debounce;
 
 class GlobalFunctionTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_passes_calls_to_the_container()
     {
         $this->mock(Debouncer::class, function ($mock) {

--- a/tests/ProviderHotSwapTest.php
+++ b/tests/ProviderHotSwapTest.php
@@ -9,10 +9,11 @@ use Illuminate\Support\Facades\Cache;
 use Mpbarlow\LaravelQueueDebouncer\Debouncer;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\HotSwappedCacheKeyProvider;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\HotSwappedIdentifierProvider;
+use PHPUnit\Framework\Attributes\Test;
 
 class ProviderHotSwapTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function the_cache_key_provider_can_be_hot_swapped()
     {
         Bus::fake();
@@ -32,7 +33,7 @@ class ProviderHotSwapTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function the_identifier_provider_can_be_hot_swapped()
     {
         Bus::fake();

--- a/tests/SerializingCacheKeyProviderTest.php
+++ b/tests/SerializingCacheKeyProviderTest.php
@@ -7,10 +7,11 @@ namespace Mpbarlow\LaravelQueueDebouncer\Tests;
 use Mpbarlow\LaravelQueueDebouncer\Support\SerializingCacheKeyProvider;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\DummyJob;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\DummyJobWithArgs;
+use PHPUnit\Framework\Attributes\Test;
 
 class SerializingCacheKeyProviderTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_generates_the_same_key_when_objects_are_equal()
     {
         $provider = new SerializingCacheKeyProvider();
@@ -24,7 +25,7 @@ class SerializingCacheKeyProviderTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_a_unique_key_when_objects_are_not_equal()
     {
         $provider = new SerializingCacheKeyProvider();
@@ -38,7 +39,7 @@ class SerializingCacheKeyProviderTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_allows_for_chains_to_be_debounced()
     {
         $provider = new SerializingCacheKeyProvider();

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -8,10 +8,11 @@ use Mpbarlow\LaravelQueueDebouncer\Contracts\CacheKeyProvider as CacheKeyProvide
 use Mpbarlow\LaravelQueueDebouncer\Contracts\UniqueIdentifierProvider as UniqueIdentifierProviderContract;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\CustomCacheKeyProvider;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\CustomUniqueIdentifierProvider;
+use PHPUnit\Framework\Attributes\Test;
 
 class ServiceProviderTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_fetches_the_cache_key_provider_from_the_config()
     {
         $this->app['config']->set('queue_debouncer.cache_key_provider', CustomCacheKeyProvider::class);
@@ -22,7 +23,7 @@ class ServiceProviderTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_fetches_the_unique_identifier_provider_from_the_config()
     {
         $this->app['config']->set('queue_debouncer.unique_identifier_provider', CustomUniqueIdentifierProvider::class);

--- a/tests/SharedCacheKeyProviderTest.php
+++ b/tests/SharedCacheKeyProviderTest.php
@@ -8,14 +8,14 @@ use Mpbarlow\LaravelQueueDebouncer\Support\CacheKeyProvider;
 use Mpbarlow\LaravelQueueDebouncer\Support\SerializingCacheKeyProvider;
 use Mpbarlow\LaravelQueueDebouncer\Tests\Support\DummyJob;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use function strpos;
 
 class SharedCacheKeyProviderTest extends TestCase
 {
-    /**
-     * @test
-     * @dataProvider cacheKeyProviderProvider
-     */
+    #[Test]
+    #[DataProvider('cacheKeyProviderProvider')]
     public function it_applies_the_cache_prefix_to_classes($provider)
     {
         $this->app['config']->set('queue_debouncer.cache_prefix', $prefix = '__PREFIX__');
@@ -28,10 +28,8 @@ class SharedCacheKeyProviderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     * @dataProvider cacheKeyProviderProvider
-     */
+    #[Test]
+    #[DataProvider('cacheKeyProviderProvider')]
     public function it_applies_the_cache_prefix_to_chains($provider)
     {
         $this->app['config']->set('queue_debouncer.cache_prefix', $prefix = '__PREFIX__');
@@ -44,10 +42,8 @@ class SharedCacheKeyProviderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     * @dataProvider cacheKeyProviderProvider
-     */
+    #[Test]
+    #[DataProvider('cacheKeyProviderProvider')]
     public function it_applies_the_cache_prefix_to_closures($provider)
     {
         $this->app['config']->set('queue_debouncer.cache_prefix', $prefix = '__PREFIX__');
@@ -61,10 +57,8 @@ class SharedCacheKeyProviderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     * @dataProvider cacheKeyProviderProvider
-     */
+    #[Test]
+    #[DataProvider('cacheKeyProviderProvider')]
     public function it_generates_a_unique_key_for_closures($provider)
     {
         $job1 = function () {
@@ -79,10 +73,8 @@ class SharedCacheKeyProviderTest extends TestCase
         $this->assertNotEquals($key1, $key2);
     }
 
-    /**
-     * @test
-     * @dataProvider cacheKeyProviderProvider
-     */
+    #[Test]
+    #[DataProvider('cacheKeyProviderProvider')]
     public function it_generates_a_consistent_key_for_closures($provider)
     {
         $job = function () {
@@ -95,7 +87,7 @@ class SharedCacheKeyProviderTest extends TestCase
         $this->assertEquals($key1, $key2);
     }
 
-    public function cacheKeyProviderProvider()
+    public static function cacheKeyProviderProvider()
     {
         return [
             [new CacheKeyProvider()],

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,14 +9,14 @@ use Mpbarlow\LaravelQueueDebouncer\ServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             ServiceProvider::class
         ];
     }
 
-    protected function getPackageAliases($app)
+    protected function getPackageAliases($app): array
     {
         return [
             'Debouncer' => Debouncer::class

--- a/tests/UniqueIdentifierProviderTest.php
+++ b/tests/UniqueIdentifierProviderTest.php
@@ -6,13 +6,14 @@ namespace Mpbarlow\LaravelQueueDebouncer\Tests;
 
 use Mpbarlow\LaravelQueueDebouncer\Support\UniqueIdentifierProvider;
 
+use PHPUnit\Framework\Attributes\Test;
 use function array_fill;
 use function array_map;
 use function collect;
 
 class UniqueIdentifierProviderTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_generates_unique_identifiers()
     {
         $provider = new UniqueIdentifierProvider();


### PR DESCRIPTION
This brings that wonderful package back in shape, supporting PHP 8.4:

- Replace `opis/closure` by `laravel/serializable-closure` for PHP 8.4 support
- Upgrade to PHPUnit 11.5, replacing deprecated docblock annotations with attributes
- Drop PHP versions below 8.1
- Drop Laravel versions below 10.x